### PR TITLE
corrected page numbering

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -120,6 +120,7 @@
 
 
 \begin{document}
+\pagenumbering{roman}
 
   \pagestyle{empty}
 
@@ -209,9 +210,6 @@ Ich versichere, dass ich diese Masterarbeit selbständig verfasst und nur die an
 \ \\
 \vfill
 
-% Seitenzahlen (Ziffern), Seite 1 ab hier.
-\setcounter{page}{1}
-\pagenumbering{roman}
 \pagestyle{plain} % fancy
 
 
@@ -241,11 +239,10 @@ Ich versichere, dass ich diese Masterarbeit selbständig verfasst und nur die an
 \addchap*{Abbildungs- und Tabellenverzeichnis}
 \listoffigures
 \listoftables % Rausnehmen, falls es keine Tabelle gibt.
+
+
 \cleardoublepage
-
-
 % Seitenzahlen (Ziffern), Seite 1 ab hier.
-%\setcounter{page}{1}
 \pagenumbering{arabic}
 \pagestyle{plain} % fancy
 


### PR DESCRIPTION
Die Nummerierung beginnt im Normalfall mit der Titelseite als Seite eins. Das Inhalts verzeichnis hat im Allgemeinen eine Seitenzahl von 2n+1 (n>0).