### PR TITLE
pdftex option removed, pslatex as well

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -1,4 +1,4 @@
-\documentclass[a4paper,12pt,pdftex,oneside,halfparskip]{scrreprt}
+\documentclass[a4paper,12pt,oneside,halfparskip]{scrreprt}
 
 % Font von http://www.tug.dk/FontCatalogue/garamond/
 % Zur Installation siehe auch (Shell-Befehl: "getnonfreefonts garamond classico")
@@ -10,7 +10,6 @@
 % pdfLaTeX, they look ugly.Always include the "lmodern" or "pslatex" package,
 % that uses much better postscript fonts.
 %\usepackage[lmodern]{}
-\usepackage[pslatex]{}
 
 \usepackage[T1]{fontenc}
 \usepackage[utf8]{inputenc}
@@ -36,7 +35,7 @@
 \addbibresource{thesis.bib}
 
 \usepackage{url}
-\usepackage[pdftex,
+\usepackage[
 		unicode=true,
 		colorlinks=false,
 		pdfborder={0 0 0},


### PR DESCRIPTION
Option pdftex sowohl global, als auch bei hyperref entfernt. Das macht heutzutage nichts nützliches und schadet im schlimmsten Fall. Das mehr als obsolete Paket `pslatex` ist auch raus. 
